### PR TITLE
rlang Depends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ Depends:
     R (>= 3.0),
 	GOTMr,
     rLakeAnalyzer (>= 1.8.3)
+    rlang (>= 0.4.2)
 Imports:
     ncdf4,
     tools,


### PR DESCRIPTION
rlang >= 0.4.2 is required as per https://github.com/aemon-j/LakeEnsemblR/issues/58

When installing the LakeEnslembR package it became clear than rlang >= 0.4.2 is required so I have added it into the DESCRIPTION.