### PR TITLE
Prevent input_ or get_yaml_value error if label/key occurs in comment

### DIFF
--- a/R/get_yaml_value.R
+++ b/R/get_yaml_value.R
@@ -1,11 +1,9 @@
-#' @title Extract values frpm yaml file
+#' @title Extract values from yaml file
 #' @description
 #'Inputs values into yaml file by locating the label and key within the yaml file. Preserves comments (#) if present. NOTE: this does not use a yaml parser so if there are yaml formatting errors this function will not pick them up.
 #' @param file filepath; to .yaml which you wish to edit
 #' @param label string; which corresponds to section where the key is located
 #' @param key string; name of key in which to input the value
-#' @param value string; to be input into the key/value pair. Note boolean values must be input as 'true'/'false' as per the yaml format
-#' @param out_file filepath; to write the output yaml file (optional); defaults to overwriting file if not specified
 #' @export
 #' @author
 #'Tadhg Moore
@@ -16,13 +14,16 @@
 #'
 get_yaml_value <- function(file = 'gotm.yaml', label, key){
   yml <- readLines(file)
+  
+  # Prevent from finding labels/keys in comments
+  yml_no_comments <- unname(sapply(yml, function(x) strsplit(x, "#")[[1]][1]))
 
   #Find index of label
   if(is.null(label)){
     ind_label = 0
   }else{
     label_id <- paste0(label,':')
-    ind_label <- grep(label_id, yml)
+    ind_label <- grep(label_id, yml_no_comments)
     
     if(length(ind_label) == 0){
       stop(label, ' not found in ', file)
@@ -31,7 +32,7 @@ get_yaml_value <- function(file = 'gotm.yaml', label, key){
 
   #Find index of key to replace
   key_id <- paste0(' ',key, ':')
-  ind_key = grep(key_id, yml)
+  ind_key = grep(key_id, yml_no_comments)
   if(length(ind_key) == 0){
     stop(key, ' not found in ', label, ' in ', file)
   }

--- a/R/input_yaml.R
+++ b/R/input_yaml.R
@@ -16,7 +16,10 @@
 
 input_yaml <- function(file = 'gotm.yaml', label, key, value, out_file = NULL){
   yml <- readLines(file)
-
+  
+  # Prevent from finding labels/keys in comments
+  yml_no_comments <- unname(sapply(yml, function(x) strsplit(x, "#")[[1]][1]))
+  
   if(is.null(out_file)){
     out_file = file
   }
@@ -26,7 +29,7 @@ input_yaml <- function(file = 'gotm.yaml', label, key, value, out_file = NULL){
     ind_label = 0
   }else{
     label_id <- paste0(label,':')
-    ind_label <- grep(label_id, yml)
+    ind_label <- grep(label_id, yml_no_comments)
     
     if(length(ind_label) == 0){
       stop(label, ' not found in ', file)
@@ -35,7 +38,7 @@ input_yaml <- function(file = 'gotm.yaml', label, key, value, out_file = NULL){
 
   #Find index of key to replace
   key_id <- paste0(' ',key, ':')
-  ind_key = grep(key_id, yml)
+  ind_key = grep(key_id, yml_no_comments)
   if(length(ind_key) == 0){
     stop(key, ' not found in ', label, ' in ', file)
   }

--- a/R/setmodDepths.R
+++ b/R/setmodDepths.R
@@ -13,36 +13,56 @@
 #' @import utils
 #' @export
 setmodDepths <- function(mod.val, mod.dep, obs = NULL, depths, method = "linear", print = T){
-  dep = c()
-  tmp = c()
-  dates = c()
-  pb = txtProgressBar(min = 0, max = nrow(mod.val), style = 3)
   if(is.null(obs)){
     deps = depths
-  }
-  for (i in 1:nrow(mod.val)) {
-    ind = which(obs[, 1] == mod.val[i, 1])
-    if(!is.null(obs)){
-      deps = obs[ind, 2]
-    }
-    y = mod.val[i, 2:ncol(mod.val)]
-    x = mod.dep[i, 2:ncol(mod.dep)]
-    if (method == "linear"){
-      tmp = append(tmp, approx(x, y, deps, rule = 2)$y)
-    }else if (method == "spline"){
-      sm = smooth.spline(x = x, y = y, df = 4, spar = 0.3)
-      tmp = append(tmp, predict(sm, deps)$y)
+    
+    if(method == "linear"){
+      tmp2 = lapply(1:nrow(mod.val), function(i) 
+        approx(mod.dep[i, 2:ncol(mod.dep)], mod.val[i, 2:ncol(mod.val)], deps, rule = 2)$y)
+    }else if(method == "spline"){
+      tmp2 = lapply(1:nrow(mod.val), function(i) 
+        predict(smooth.spline(x = mod.dep[i, 2:ncol(mod.dep)], y = mod.val[i, 2:ncol(mod.val)],
+                              df = 4, spar = 0.3),
+                deps)$y)
     }else{
       print("Specify method for interpolation")
     }
-    dep = append(dep, deps)
-    dates = append(dates, rep(mod.val[i,1], length(deps)))
-    if (print == T) {
-      setTxtProgressBar(pb, i)
+    
+    dep = rep(deps, nrow(mod.val))
+    dates = lapply(1:nrow(mod.val), function(i) rep(mod.val[i,1], length(deps)))
+    
+    df = data.frame(date = do.call("c", dates), depths = unlist(dep), value = unlist(tmp2))
+    return(df)
+    
+  }else{
+    dep = c()
+    tmp = c()
+    dates = c()
+    pb = txtProgressBar(min = 0, max = nrow(mod.val), style = 3)
+    
+    for (i in 1:nrow(mod.val)) {
+      ind = which(obs[, 1] == mod.val[i, 1])
+      deps = obs[ind, 2]
+      
+      y = mod.val[i, 2:ncol(mod.val)]
+      x = mod.dep[i, 2:ncol(mod.dep)]
+      if (method == "linear"){
+        tmp = append(tmp, approx(x, y, deps, rule = 2)$y)
+      }else if (method == "spline"){
+        sm = smooth.spline(x = x, y = y, df = 4, spar = 0.3)
+        tmp = append(tmp, predict(sm, deps)$y)
+      }else{
+        print("Specify method for interpolation")
+      }
+      dep = append(dep, deps)
+      dates = append(dates, rep(mod.val[i,1], length(deps)))
+      if (print == T) {
+        setTxtProgressBar(pb, i)
+      }
     }
+    close(pb)
+    df = data.frame(date = dates, depths = dep, value = tmp)
+    return(df)
+    
   }
-  close(pb)
-  df = data.frame(date = dates, depths = dep, value = tmp)
-  return(df)
 }
-

--- a/man/get_yaml_value.Rd
+++ b/man/get_yaml_value.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/get_yaml_value.R
 \name{get_yaml_value}
 \alias{get_yaml_value}
-\title{Extract values frpm yaml file}
+\title{Extract values from yaml file}
 \usage{
 get_yaml_value(file = "gotm.yaml", label, key)
 }
@@ -12,10 +12,6 @@ get_yaml_value(file = "gotm.yaml", label, key)
 \item{label}{string; which corresponds to section where the key is located}
 
 \item{key}{string; name of key in which to input the value}
-
-\item{value}{string; to be input into the key/value pair. Note boolean values must be input as 'true'/'false' as per the yaml format}
-
-\item{out_file}{filepath; to write the output yaml file (optional); defaults to overwriting file if not specified}
 }
 \description{
 Inputs values into yaml file by locating the label and key within the yaml file. Preserves comments (#) if present. NOTE: this does not use a yaml parser so if there are yaml formatting errors this function will not pick them up.


### PR DESCRIPTION
Label and key are found in yml_no_comments instead. Rest of function remains the same. 